### PR TITLE
Windows build support

### DIFF
--- a/makefile.mingw
+++ b/makefile.mingw
@@ -1,0 +1,47 @@
+
+PIDGIN_TREE_TOP ?= ../pidgin-2.10.11
+WIN32_DEV_TOP ?= $(PIDGIN_TREE_TOP)/../win32-dev
+
+#only defined on 64-bit windows
+PROGFILES32 = ${ProgramFiles(x86)}
+ifndef PROGFILES32
+PROGFILES32 = $(PROGRAMFILES)
+endif
+
+PLUGIN_DIR_PURPLE	=  "$(PROGFILES32)/Pidgin/plugins"
+
+CC	?= $(WIN32_DEV_TOP)/mingw-4.7.2/bin/gcc
+CFLAGS	?= -O2 -g -ggdb -pipe
+LDFLAGS ?= -ljabber
+PKG_CONFIG  ?= pkg-config
+
+DIR_PERM	= 0755
+FILE_PERM	= 0644
+
+HEADERS = -I./headers/jabber
+
+CFLAGS	+= -I$(WIN32_DEV_TOP)/glib-2.28.8/include -I$(WIN32_DEV_TOP)/glib-2.28.8/include/glib-2.0 -I$(WIN32_DEV_TOP)/glib-2.28.8/lib/glib-2.0/include -I$(WIN32_DEV_TOP)/glib-2.28.8/gio-2.0 -DENABLE_NLS -I$(PIDGIN_TREE_TOP)/libpurple -I$(PIDGIN_TREE_TOP) -I$(WIN32_DEV_TOP)/libxml2-2.9.0/include/libxml2 $(HEADERS)
+LIBS	+= -L$(PIDGIN_TREE_TOP)/libpurple -L$(PIDGIN_TREE_TOP)/libpurple/protocols/jabber/ -L$(WIN32_DEV_TOP)/glib-2.28.8/lib -L$(WIN32_DEV_TOP)/libxml2-2.9.0/lib -lpurple -lintl -lglib-2.0 -lgio-2.0 -lxml2 -static-libgcc -lz 
+
+
+
+PRPL_NAME	= jabber_http_file_upload.dll
+PRPL_LIBNAME	= ${PRPL_NAME}
+
+SKYPEWEB_SOURCES = \
+	src/hfu_disco.c \
+	src/hfu_util.c \
+	src/jabber_http_file_upload.c
+
+
+.PHONY:	all clean install
+all: $(PRPL_NAME)
+install: $(PRPL_LIBNAME)
+	mkdir -m $(DIR_PERM) -p $(DESTDIR)$(PLUGIN_DIR_PURPLE)
+	install -m $(FILE_PERM) $(PRPL_LIBNAME) $(DESTDIR)$(PLUGIN_DIR_PURPLE)/$(PRPL_NAME)
+
+clean:
+	rm -f $(PRPL_NAME)
+
+$(PRPL_NAME): $(SKYPEWEB_SOURCES)
+	$(CC)  -Wall -I. $(CFLAGS) $(SKYPEWEB_SOURCES) -o $@ $(CFLAGS) $(LIBS) $(LDFLAGS) -shared

--- a/src/jabber_http_file_upload.c
+++ b/src/jabber_http_file_upload.c
@@ -82,13 +82,13 @@ static void jabber_hfu_http_send_connect_cb(gpointer data, PurpleSslConnection *
     headers = g_strdup_printf("PUT /%s HTTP/1.0\r\n"
             "Connection: close\r\n"
             "Host: %s\r\n"
-            "Content-Length: %zu\r\n"
+            "Content-Length: %" G_GSIZE_FORMAT "\r\n"
             "Content-Type: application/octet-stream\r\n"
             "User-Agent: libpurple\r\n"
             "\r\n",
             path,
             host,
-            purple_xfer_get_size(xfer));
+            (gsize) purple_xfer_get_size(xfer));
 
     //add headers!!!
 
@@ -207,7 +207,7 @@ static void jabber_hfu_send_request(PurpleXfer *xfer)
 
     filename = purple_xfer_get_filename(xfer);
     filepath = purple_xfer_get_local_filename(xfer);
-    filesize = g_strdup_printf("%zu", purple_xfer_get_size(xfer));
+    filesize = g_strdup_printf("%" G_GSIZE_FORMAT, (gsize) purple_xfer_get_size(xfer));
     filemime = file_get_mime(filepath);
 
     if (str_equal(js_data->ns, NS_HTTP_FILE_UPLOAD_V0))


### PR DESCRIPTION
Adds a Windows makefile, based on a standard Pidgin build setup: https://developer.pidgin.im/wiki/BuildingWinPidgin

Also fixes a printf() incompatiblity `%z` isn't a thing on Windows, but glib provides the `G_GSIZE_FORMAT` macro