### PR TITLE
Fix windows/mingw build.

### DIFF
--- a/src/jabber_http_file_upload.c
+++ b/src/jabber_http_file_upload.c
@@ -42,6 +42,7 @@ static inline PurpleHttpURL *purple_http_url_parse(const gchar *url) {
     return ret;
 }
 
+GHashTable *HFUJabberStreamDataTable;
 GHashTable *ht_hfu_sending;
 
 #define purple_http_url_get_host(httpurl) (httpurl->host)
@@ -60,7 +61,7 @@ static void jabber_hfu_http_read(gpointer user_data, PurpleSslConnection *ssl_co
 
     //Read the server buffer
     size_t rl = purple_ssl_read(ssl_connection, buf, 1024);
-    purple_debug_info("jabber_http_upload", "Server file send response was %ld bytes: %s\n", rl, buf);
+    purple_debug_info("jabber_http_upload", "Server file send response was %" G_GSIZE_FORMAT " bytes: %s\n", (gsize) rl, buf);
 
     if(rl == (size_t)-1)
 	return;
@@ -82,12 +83,12 @@ static void jabber_hfu_http_read(gpointer user_data, PurpleSslConnection *ssl_co
 static void jabber_hfu_http_send_connect_cb(gpointer data, PurpleSslConnection *ssl_connection, PurpleInputCondition cond)
 {
     PurpleHttpURL *httpurl;
-    g_autofree gchar *headers, *auth = NULL, *expire = NULL, *cookie = NULL;
+    gchar *headers, *auth = NULL, *expire = NULL, *cookie = NULL;
 
     PurpleXfer *xfer = data;
     HFUXfer *hfux = purple_xfer_get_protocol_data(xfer);
     HFUJabberStreamData *js_data = hfux->js_data;
-    g_autofree char *filemime = file_get_mime(purple_xfer_get_local_filename(xfer));
+    char *filemime = file_get_mime(purple_xfer_get_local_filename(xfer));
 
     httpurl = purple_http_url_parse(hfux->put_url);
 
@@ -116,10 +117,16 @@ static void jabber_hfu_http_send_connect_cb(gpointer data, PurpleSslConnection *
 	    (filemime?:"application/octet-stream"),
 	    (auth?:""), (expire?:""), (cookie?:""));
 
+    g_free(auth);
+    g_free(expire);
+    g_free(cookie);
+    g_free(filemime);
+
     hfux->ssl_conn = ssl_connection;
     purple_ssl_input_add(ssl_connection, jabber_hfu_http_read, xfer);
 
     purple_ssl_write(ssl_connection, headers, strlen(headers));
+    g_free(headers);
 
     purple_xfer_ref(xfer);
     purple_xfer_start(xfer, ssl_connection->fd, NULL, 0);
@@ -269,8 +276,9 @@ jabber_hfu_xmlnode_send_cb(PurpleConnection *gc, xmlnode **packet, gpointer null
     if (g_strcmp0 ((*packet)->name, "message") == 0) {
       xmlnode *node_body = xmlnode_get_child (*packet, "body");
       if (node_body) {
-	g_autofree char *url = xmlnode_get_data(node_body);
+	char *url = xmlnode_get_data(node_body);
         HFUXfer *hfux = g_hash_table_lookup(ht_hfu_sending, url);
+	g_free(url);
         if(hfux) {
            xmlnode *x, *url;
            x = xmlnode_new_child (*packet, "x");

--- a/src/jabber_http_file_upload.h
+++ b/src/jabber_http_file_upload.h
@@ -16,7 +16,7 @@ typedef struct _HFUXfer {
     GHashTable *put_headers;
 } HFUXfer;
 
-GHashTable *HFUJabberStreamDataTable;
+extern GHashTable *HFUJabberStreamDataTable;
 
 #define NS_HTTP_FILE_UPLOAD "urn:xmpp:http:upload"
 #define NS_HTTP_FILE_UPLOAD_V0 "urn:xmpp:http:upload:0"


### PR DESCRIPTION
fbbd41 (Pull request #16) added g_autofree, which is not supported on the old version of GTK in the pidgin-windev.

Fix a size_t printf format (on Windows, size_t is not necessarily the same as unsigned long)

Fix a duplicate symbol at link by declaring HFUJabberStreamDataTable extern in the header, and only defining it in jabber_http_file_upload.c.