### PR TITLE
jabber_http_file_upload: fix build with gcc 10

### DIFF
--- a/src/jabber_http_file_upload.c
+++ b/src/jabber_http_file_upload.c
@@ -26,6 +26,8 @@
 #include "hfu_util.h"
 #include "jabber_http_file_upload.h"
 
+GHashTable *HFUJabberStreamDataTable;
+
 GList *(*old_blist_node_menu)(PurpleBlistNode *node);
 
 typedef struct {

--- a/src/jabber_http_file_upload.h
+++ b/src/jabber_http_file_upload.h
@@ -16,7 +16,7 @@ typedef struct _HFUXfer {
     GHashTable *put_headers;
 } HFUXfer;
 
-GHashTable *HFUJabberStreamDataTable;
+extern GHashTable *HFUJabberStreamDataTable;
 
 #define NS_HTTP_FILE_UPLOAD "urn:xmpp:http:upload"
 #define NS_HTTP_FILE_UPLOAD_V0 "urn:xmpp:http:upload:0"


### PR DESCRIPTION
With GCC 10, `HFUJabberStreamDataTable` being declared in a header file 
leads to the creation of 2 objects with that name: one when compiling 
`hfu_disco.c`, the other one when compiling `jabber_http_file_upload.c`.

This results in link-time errors, which can be fixed by declaring 
`HFUJabberStreamDataTable` as `extern`.